### PR TITLE
Add robot path following demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,8 @@
             <div id="toolbar">
                 <button id="block-tool" class="tool-btn active">Block</button>
                 <button id="projectile-tool" class="tool-btn">Ball</button>
+                <button id="dot-tool" class="tool-btn">Dot</button>
+                <button id="robot-tool" class="tool-btn">Robot</button>
                 <div id="material-selector">
                     <select id="material-select">
                         <option value="wood">Wood</option>
@@ -22,7 +24,7 @@
                 </div>
             </div>
             <div id="info-panel">
-                <p>Click to place blocks, drag to launch projectiles</p>
+                <p>Click to place blocks, drag to launch projectiles. Use Dot and Robot tools for path following demos.</p>
             </div>
         </div>
     </div>

--- a/src/core/ecs.js
+++ b/src/core/ecs.js
@@ -94,5 +94,7 @@ export const ComponentTypes = {
     PHYSICS: 'physics',
     RENDERABLE: 'renderable',
     INPUT: 'input',
-    LIFETIME: 'lifetime'
+    LIFETIME: 'lifetime',
+    ROBOT: 'robot',
+    DOT: 'dot'
 };

--- a/src/entities/dot.js
+++ b/src/entities/dot.js
@@ -1,0 +1,33 @@
+import { ComponentTypes } from '../core/ecs.js';
+
+/**
+ * Simple yellow dot that acts as a navigation waypoint
+ * for robots.
+ */
+export class DotFactory {
+    constructor(ecs) {
+        this.ecs = ecs;
+    }
+
+    create(x, y) {
+        const entityId = this.ecs.createEntity();
+
+        this.ecs.addComponent(entityId, ComponentTypes.TRANSFORM, {
+            x,
+            y,
+            rotation: 0,
+            scaleX: 1,
+            scaleY: 1
+        });
+
+        this.ecs.addComponent(entityId, ComponentTypes.DOT, {});
+
+        this.ecs.addComponent(entityId, ComponentTypes.RENDERABLE, {
+            type: 'dot',
+            radius: 5,
+            color: '#FFD800'
+        });
+
+        return entityId;
+    }
+}

--- a/src/entities/robot.js
+++ b/src/entities/robot.js
@@ -1,0 +1,47 @@
+import { ComponentTypes } from '../core/ecs.js';
+
+/**
+ * Factory for creating a simple wheeled robot composed of
+ * a rectangular body with a spherical head and two wheels.
+ * Physics is not currently used; the robot is moved
+ * manually by the RobotSystem.
+ */
+export class RobotFactory {
+    constructor(ecs) {
+        this.ecs = ecs;
+    }
+
+    /**
+     * Create a robot entity.
+     * @param {number} x Initial x position
+     * @param {number} y Initial y position
+     * @returns {number} entity id
+     */
+    create(x, y) {
+        const entityId = this.ecs.createEntity();
+
+        this.ecs.addComponent(entityId, ComponentTypes.TRANSFORM, {
+            x: x,
+            y: y,
+            rotation: 0,
+            scaleX: 1,
+            scaleY: 1
+        });
+
+        // stores robot specific state
+        this.ecs.addComponent(entityId, ComponentTypes.ROBOT, {
+            speed: 60,      // pixels per second
+            targetId: null  // current dot entity being followed
+        });
+
+        this.ecs.addComponent(entityId, ComponentTypes.RENDERABLE, {
+            type: 'robot',
+            bodyWidth: 30,
+            bodyHeight: 60,
+            wheelRadius: 10,
+            headRadius: 15
+        });
+
+        return entityId;
+    }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,7 @@ import { RenderSystem } from './systems/render-system.js';
 import { InputSystem } from './systems/input-system.js';
 import { GameSystem } from './systems/game-system.js';
 import { LifetimeSystem } from './systems/lifetime-system.js';
+import { RobotSystem } from './systems/robot-system.js';
 
 class PhysicsAdventure {
     constructor() {
@@ -28,10 +29,12 @@ class PhysicsAdventure {
         this.inputSystem = new InputSystem(this.canvas, this.gameEngine.eventBus);
         this.gameSystem = new GameSystem(this.physicsSystem, this.renderer, this.gameEngine.eventBus);
         this.lifetimeSystem = new LifetimeSystem(this.physicsSystem);
+        this.robotSystem = new RobotSystem();
         
         this.gameEngine.ecs.addSystem(this.physicsSystem);
         this.gameEngine.ecs.addSystem(this.renderSystem);
         this.gameEngine.ecs.addSystem(this.gameSystem);
+        this.gameEngine.ecs.addSystem(this.robotSystem);
         this.gameEngine.ecs.addSystem(this.lifetimeSystem);
         
         this.setupEventListeners();
@@ -60,6 +63,12 @@ class PhysicsAdventure {
                     break;
                 case '2':
                     this.inputSystem.setTool('projectile');
+                    break;
+                case '3':
+                    this.inputSystem.setTool('dot');
+                    break;
+                case '4':
+                    this.inputSystem.setTool('robot');
                     break;
                 case 'r':
                     this.resetGame();

--- a/src/rendering/canvas-renderer.js
+++ b/src/rendering/canvas-renderer.js
@@ -59,6 +59,41 @@ export class CanvasRenderer {
         this.ctx.restore();
     }
 
+    /** Draw a simple yellow waypoint dot */
+    drawDot(x, y, radius, color = '#FFD800') {
+        this.drawCircle(x, y, radius, color);
+    }
+
+    /**
+     * Render a robot composed of a body, wheels and a head with eyes.
+     * @param {number} x center x
+     * @param {number} y center y (at bottom of torso)
+     * @param {object} options rendering sizes
+     */
+    drawRobot(x, y, options) {
+        const { bodyWidth, bodyHeight, wheelRadius, headRadius } = options;
+
+        // draw wheels
+        const halfBody = bodyWidth / 2;
+        const wheelY = y + wheelRadius;
+        this.drawCircle(x - halfBody + wheelRadius, wheelY, wheelRadius, '#555');
+        this.drawCircle(x + halfBody - wheelRadius, wheelY, wheelRadius, '#555');
+
+        // draw body
+        this.drawRect(x, y - bodyHeight / 2, bodyWidth, bodyHeight, '#AAA');
+
+        // draw head
+        const headY = y - bodyHeight - headRadius;
+        this.drawCircle(x, headY, headRadius, '#CCC');
+
+        // eyes
+        const eyeOffsetX = headRadius * 0.4;
+        const eyeOffsetY = headRadius * -0.2;
+        const eyeRadius = headRadius * 0.2;
+        this.drawCircle(x - eyeOffsetX, headY + eyeOffsetY, eyeRadius, '#00AEEF');
+        this.drawCircle(x + eyeOffsetX, headY + eyeOffsetY, eyeRadius, '#00AEEF');
+    }
+
     drawText(text, x, y, options = {}) {
         this.ctx.save();
         this.ctx.fillStyle = options.color || '#fff';

--- a/src/systems/game-system.js
+++ b/src/systems/game-system.js
@@ -2,6 +2,8 @@ import { System } from '../core/ecs.js';
 import { EventTypes } from '../core/events.js';
 import { BlockFactory } from '../entities/block.js';
 import { ProjectileFactory } from '../entities/projectile.js';
+import { RobotFactory } from '../entities/robot.js';
+import { DotFactory } from '../entities/dot.js';
 
 export class GameSystem extends System {
     constructor(physicsSystem, renderer, eventBus) {
@@ -12,6 +14,8 @@ export class GameSystem extends System {
         
         this.blockFactory = new BlockFactory(null, physicsSystem);
         this.projectileFactory = new ProjectileFactory(null, physicsSystem);
+        this.robotFactory = new RobotFactory(null);
+        this.dotFactory = new DotFactory(null);
         
         this.dragPreview = null;
         this.setupEventListeners();
@@ -26,6 +30,8 @@ export class GameSystem extends System {
     update(deltaTime) {
         this.blockFactory.ecs = this.ecs;
         this.projectileFactory.ecs = this.ecs;
+        this.robotFactory.ecs = this.ecs;
+        this.dotFactory.ecs = this.ecs;
         
         if (this.dragPreview && this.dragPreview.tool === 'projectile') {
             this.renderTrajectoryPreview();
@@ -42,6 +48,10 @@ export class GameSystem extends System {
                 current: { x: data.x, y: data.y },
                 material: data.material
             };
+        } else if (data.tool === 'robot') {
+            this.robotFactory.create(data.x, data.y);
+        } else if (data.tool === 'dot') {
+            this.dotFactory.create(data.x, data.y);
         }
     }
 

--- a/src/systems/input-system.js
+++ b/src/systems/input-system.js
@@ -29,6 +29,10 @@ export class InputSystem extends System {
         
         document.getElementById('block-tool').addEventListener('click', () => this.setTool('block'));
         document.getElementById('projectile-tool').addEventListener('click', () => this.setTool('projectile'));
+        const dotBtn = document.getElementById('dot-tool');
+        if (dotBtn) dotBtn.addEventListener('click', () => this.setTool('dot'));
+        const robotBtn = document.getElementById('robot-tool');
+        if (robotBtn) robotBtn.addEventListener('click', () => this.setTool('robot'));
         document.getElementById('material-select').addEventListener('change', (e) => {
             this.currentMaterial = e.target.value;
         });

--- a/src/systems/render-system.js
+++ b/src/systems/render-system.js
@@ -46,6 +46,21 @@ export class RenderSystem extends System {
                     renderable.color
                 );
                 break;
+            case 'dot':
+                this.renderer.drawDot(
+                    transform.x,
+                    transform.y,
+                    renderable.radius,
+                    renderable.color
+                );
+                break;
+            case 'robot':
+                this.renderer.drawRobot(
+                    transform.x,
+                    transform.y,
+                    renderable
+                );
+                break;
             case 'sprite':
                 break;
             default:

--- a/src/systems/robot-system.js
+++ b/src/systems/robot-system.js
@@ -1,0 +1,60 @@
+import { System, ComponentTypes } from '../core/ecs.js';
+
+/**
+ * System that moves robots towards the nearest yellow dot.
+ */
+export class RobotSystem extends System {
+    constructor() {
+        super();
+    }
+
+    update(deltaTime) {
+        const robots = this.ecs.getEntitiesWithComponents(ComponentTypes.ROBOT, ComponentTypes.TRANSFORM);
+        const dots = this.ecs.getEntitiesWithComponents(ComponentTypes.DOT, ComponentTypes.TRANSFORM);
+
+        robots.forEach(robotId => {
+            const robotComp = this.ecs.getComponent(robotId, ComponentTypes.ROBOT);
+            const transform = this.ecs.getComponent(robotId, ComponentTypes.TRANSFORM);
+
+            // select next target if needed
+            if (!robotComp.targetId || !this.ecs.entities.has(robotComp.targetId)) {
+                let closest = null;
+                let closestDist = Infinity;
+                dots.forEach(dotId => {
+                    const dotTransform = this.ecs.getComponent(dotId, ComponentTypes.TRANSFORM);
+                    const dx = dotTransform.x - transform.x;
+                    const dy = dotTransform.y - transform.y;
+                    const dist = Math.hypot(dx, dy);
+                    if (dist < closestDist) {
+                        closestDist = dist;
+                        closest = dotId;
+                    }
+                });
+                robotComp.targetId = closest;
+            }
+
+            // move towards target
+            if (robotComp.targetId) {
+                const targetTransform = this.ecs.getComponent(robotComp.targetId, ComponentTypes.TRANSFORM);
+                if (targetTransform) {
+                    const dx = targetTransform.x - transform.x;
+                    const dy = targetTransform.y - transform.y;
+                    const dist = Math.hypot(dx, dy);
+                    if (dist > 1) {
+                        const dirX = dx / dist;
+                        const dirY = dy / dist;
+                        const step = robotComp.speed * deltaTime;
+                        transform.x += dirX * step;
+                        transform.y += dirY * step;
+                    } else {
+                        // reached dot
+                        this.ecs.removeEntity(robotComp.targetId);
+                        robotComp.targetId = null;
+                    }
+                } else {
+                    robotComp.targetId = null;
+                }
+            }
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- add robot and dot entities
- render robot with body, wheels and blue eyes
- add system for robots to follow placed dots
- extend input and UI with Dot and Robot tools
- include new render logic for robot/dot

## Testing
- `npm test -- --passWithNoTests`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6862fc984eac83288c97020e672bcaad